### PR TITLE
build: remove $(PRODUCT_OUT)/recovery/root on build

### DIFF
--- a/CleanSpec.mk
+++ b/CleanSpec.mk
@@ -643,6 +643,8 @@ $(call add-clean-step, rm -rf $(PRODUCT_OUT)/vendor/odm/build.prop)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/system/lib*/libcameraservice.so)
 $(call add-clean-step, rm -rf $(PRODUCT_OUT)/system/lib*/libcamera_client.so)
 
+$(call add-clean-step, rm -rf $(TARGET_RECOVERY_ROOT_OUT))
+
 # ************************************************
 # NEWER CLEAN STEPS MUST BE AT THE END OF THE LIST
 # ************************************************


### PR DESCRIPTION
Otherwise, dirty builds fail either at:
FAILED: ninja: error: mkdir(out/target/product/jasmine_sprout/recovery/root/system/lib64): No such file or directory
16:53:05 ninja failed with: exit status 1

Or at:
cannot delete non-empty directory: root/etc
could not make way for new symlink: root/etc
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1196) [sender=3.1.2]

Signed-off-by: chandra prakash <scp.thedevil@gmail.com>